### PR TITLE
Fire bufwinenter autocmd after resolving filename

### DIFF
--- a/plugin/colon-therapy.vim
+++ b/plugin/colon-therapy.vim
@@ -86,6 +86,8 @@ function! s:doPostFnameCorrectionActions(oldFname)
 
     silent doautocmd bufread
     silent doautocmd bufreadpre
+    silent doautocmd bufwinenter
+    silent doautocmd bufenter
 endfunction
 
 " =================


### PR DESCRIPTION
Fixes https://github.com/scrooloose/vim-colon-therapy/issues/2