### PR TITLE
Preserve jump list when jumping to the real file

### DIFF
--- a/plugin/colon-therapy.vim
+++ b/plugin/colon-therapy.vim
@@ -25,6 +25,7 @@ function! s:ProcessTrailingLineNum()
 
     if fname =~# s:fnameMatcher
         let oldBufNum = bufnr()
+        exec "normal! \<c-o>"
         exec 'edit ' . s:FileNameFrom(fname)
         call cursor(s:LineNumFrom(fname), s:ColNumFrom(fname))
         exec ':bwipe ' . oldBufNum


### PR DESCRIPTION
The problem is that using `:bwipeout` on a buffer that's currently inside in your jump list invalidates the whole jump list. This means that whenever you use _vim-colon-therapy_ to open a file, your jump list won't work.

This patch adds a `<C-O>` to move back one step in the jump list, before using `:edit` on the real file, so that the jump list doesn't include the buffer with the line/col number. Using `:bwipeout` won't invalidate the jump list anymore.

Note: There's no command to move through the jumplist, so `:normal!` is used instead.