### PR TITLE
Allow reloading of the plugin

### DIFF
--- a/plugin/colon-therapy.vim
+++ b/plugin/colon-therapy.vim
@@ -6,11 +6,6 @@
 "              Want To Public License, Version 2, as published by Sam Hocevar.
 "              See http://sam.zoy.org/wtfpl/COPYING for more details.
 " ============================================================================
-if exists('g:loaded_colon_therapy')
-    finish
-endif
-let g:loaded_colon_therapy = 1
-
 let s:fnameMatcher = ':\d\+\(:.*\)\?$'
 
 augroup colontherapy


### PR DESCRIPTION
Plugin managers like _vim-plug_ reload plugins on updates. _vim-colon-therapy_ has never supported this, because of the check included in the first lines of the plugin. Fortunately, the check is not needed anymore, because the script correctly reinitializes everything through `augroup` and `function!`.

Issue: https://github.com/scrooloose/vim-colon-therapy/issues/5